### PR TITLE
fix: update query parameter names for filters in HomeContent

### DIFF
--- a/src/app/HomeClient.jsx
+++ b/src/app/HomeClient.jsx
@@ -170,12 +170,12 @@ function HomeContent() {
         else if (filters.searchQuery) queryParams.append('title_includes', filters.searchQuery);
         if (filters.descriptionIncludes) queryParams.append('description_includes', filters.descriptionIncludes);
         if (filters.artistsIncludes) queryParams.append('artists_includes', filters.artistsIncludes);
-        if (filters.minRating) queryParams.append('minR', filters.minRating);
-        if (filters.maxRating) queryParams.append('maxR', filters.maxRating);
+        if (filters.minRating) queryParams.append('min_rating', filters.minRating);
+        if (filters.maxRating) queryParams.append('max_rating', filters.maxRating);
         if (typeof filters.tags === 'string' && filters.tags.trim()) queryParams.append('tags', filters.tags.trim());
         else if (Array.isArray(filters.tags) && filters.tags.length > 0) queryParams.append('tags', filters.tags.join(','));
-        if (filters.minLikes) queryParams.append('minL', filters.minLikes);
-        if (filters.maxLikes) queryParams.append('maxL', filters.maxLikes);
+        if (filters.minLikes) queryParams.append('min_likes', filters.minLikes);
+        if (filters.maxLikes) queryParams.append('max_likes', filters.maxLikes);
         if (filters.likedBy) queryParams.append('liked_by', '1');
         queryParams.append('sort_by', filters.sortBy);
         queryParams.append('sort_order', filters.sortOrder);


### PR DESCRIPTION
Before, Min Rating and Max Rating filter is not working. This is because the query param that was sent to the backend is wrong. It should've been `min_rating` and `max_rating` instead of `minR` and `maxR`

Before:
<img width="1131" height="1293" alt="image" src="https://github.com/user-attachments/assets/d542de65-9e45-4bc5-94de-282c9537e57e" />

After:
<img width="1138" height="1299" alt="image" src="https://github.com/user-attachments/assets/ba9082fc-8378-4630-a71d-27324024a727" />
